### PR TITLE
Update guzzlehttp/guzzle dependency to version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "require": {
         "php": ">=7.2",
-        "guzzlehttp/guzzle": "^6.1"
+        "guzzlehttp/guzzle": "^7.0"
     },
     "suggest": {
         "csa/guzzle-bundle": "Guzzle bundle for symfony"

--- a/src/AbstractAnonymizerFormatter.php
+++ b/src/AbstractAnonymizerFormatter.php
@@ -47,9 +47,9 @@ abstract class AbstractAnonymizerFormatter extends MessageFormatter
      */
     public function format(
         RequestInterface $request,
-        ResponseInterface $response = null,
-        \Exception $error = null
-    ) {
+        ?ResponseInterface $response = null,
+        ?\Throwable $error = null
+    ): string {
         $cache = [];
 
         return preg_replace_callback(


### PR DESCRIPTION
New versions of most packages require/support guzzle 7, as a result guzzle version was upgraded to v7