### PR TITLE
Test with PSR/log 3.x on modern PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8",
-        "wmde/psr-log-test-doubles": "^2.2"
+        "jeroen/psr-log-test-doubles": "^2.2|^3.0"
     },
     "autoload": {
         "psr-4": { "Freshcells\\GuzzleMessageAnonymizerFormatter\\": "src" }


### PR DESCRIPTION
This will pull in the latest version of the test double library when using
PHP 8.0 or later. It comes with a PSR/log 3.x implementation of LoggerInterface,
rather than 1.x in older versions.